### PR TITLE
Create requirements.txt

### DIFF
--- a/00-Install/requirements.txt
+++ b/00-Install/requirements.txt
@@ -1,0 +1,10 @@
+jupyter
+notebook>=6.0
+matplotlib>=3.8.0
+numpy>=1.25
+packaging
+pip
+pyyaml
+astropy>=5.3
+ccdproc
+pandas


### PR DESCRIPTION
A requirements.txt file has been added in case the default built-in venv module will be used.